### PR TITLE
release v0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 
 [[package]]
 name = "typr"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "typr-cli",
  "typr-core",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "typr-cli"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "typr-core"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "typr-lsp"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "typr-wasm"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ typr-cli.workspace = true
 typr-core.workspace = true
 
 [workspace.package]
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 authors = ["Fabrice Hategekimana <fab.hatege15@gmail.com>"]
 license = "Apache-2.0"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,18 +15,37 @@ et le même contrôle tourne sur chaque PR (job `coherence` de `ci.yml`).
 
 ## Procédure
 
-```bash
-git switch main && git pull
+`main` est protégée : on n'y commite pas directement. La montée de version se
+prépare sur `develop`, arrive sur `main` par une pull request, et seul le tag
+est poussé ensuite.
 
+```bash
+# 1. Préparer la version sur develop
+git switch develop && git pull
 nu publish.nu bump patch      # ou minor / major — synchronise les éditeurs
 cargo check --workspace       # met Cargo.lock à jour
+git commit -am "release v$(nu publish.nu version | head -1)"
+git push origin develop
 
-git add -A
-git commit -m "release v$(nu publish.nu version | head -1)"
+# 2. La faire passer sur main (la CI doit être verte, un relecteur doit approuver)
+gh pr create --base main --head develop --fill
+gh pr merge --merge --delete-branch=false
 
-nu publish.nu release --dry-run   # vérifie branche, propreté, tag
-nu publish.nu release             # tag + push → la CI prend le relais
+# 3. Taguer depuis main
+git switch main && git pull
+nu publish.nu release --dry-run   # branche, propreté, écart avec origin/main, tag
+nu publish.nu release             # pousse le tag seul → la CI prend le relais
+
+# 4. Remettre develop au niveau de main
+git switch develop && git merge main && git push origin develop
 ```
+
+`release` ne pousse **que le tag**. S'il détecte que `main` locale diverge de
+`origin/main`, il s'arrête : le contenu doit d'abord être passé par l'étape 2.
+
+Un numéro de version déjà publié ne se réutilise pas. `release` refuse un tag
+existant en local comme sur le distant, et `cargo publish` refuserait de toute
+façon d'écraser une version présente sur crates.io.
 
 `nu publish.nu check` compare ensuite ce qui est réellement publié sur chaque canal.
 

--- a/editors/rstudio/DESCRIPTION
+++ b/editors/rstudio/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: typr.runner
 Title: Run TypR from RStudio and Positron
-Version: 0.5.7
+Version: 0.5.8
 Authors@R: person("Fabrice", "Hategekimana", email = "fab.hatege15@gmail.com", role = c("aut", "cre"))
 Description: RStudio addins to create, check, build, test and run TypR projects
     without leaving the IDE. Wraps the TypR compiler binary, which is bundled in

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typr-language",
   "displayName": "TypR Tooling and Language Support",
   "description": "Language support for typR - A typed version of R with TypeScript-like typing and Rust-like syntax",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "publisher": "wedata-ch",
   "engines": {
     "vscode": "^1.109.0"


### PR DESCRIPTION
Monte la version à **0.5.8** sur les trois porteurs (`Cargo.toml`, extension
VS Code, runner RStudio) et corrige la procédure de release.

## Pourquoi sauter 0.5.7

0.5.7 est publiée depuis le 30 juin — tag, release GitHub et huit binaires
attachés — mais sa publication crates.io s'est arrêtée à `typr-core`, faute de
`typr-lsp` sur le registre. Le numéro est donc à moitié consommé et n'est pas
réutilisable : `cargo publish` refuserait `typr-core 0.5.7`.

0.5.8 publie les quatre crates en une fois, y compris la création de
`typr-lsp`, et résorbe du même coup l'écart de `typr` et `typr-cli` restés à
0.5.5.

## `RELEASING.md`

La procédure décrivait encore `git switch main && git commit`, devenu
impossible depuis la protection de `main`. Elle suit maintenant le circuit
réel : préparation sur `develop`, passage par pull request, tag depuis `main`,
puis remise à niveau de `develop`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFbyTtDrxK2DrN4m8xFqGC