### PR TITLE
docker: partir de rocker/r-ver et vérifier le chargement des packages R

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,19 @@
 # En CI il est téléchargé depuis la release ; en local, `nu deploy.nu` le
 # compile.
 #
-# Épingler R : remplacer `r-base:latest` par `r-base:4.5.1` par exemple.
-FROM r-base:latest
+# Base : rocker/r-ver, et non r-base.
+#
+# `r-base:latest` est construite sur Debian unstable, dont l'index apt dérive en
+# permanence par rapport aux bibliothèques figées dans l'image. Les paquets -dev
+# y exigent une version exacte de leur bibliothèque d'exécution, que l'image ne
+# porte plus : la résolution devient insoluble et le build casse sans qu'aucun
+# fichier du dépôt n'ait changé. C'est ce qui a fait échouer la release v0.5.8
+# (« libcurl4-openssl-dev Depends libcurl4t64 (= 8.21.0-2) — not installable »).
+#
+# rocker/r-ver repose sur Ubuntu LTS, dont les dépôts sont stables, et épingle
+# un instantané CRAN : le même Dockerfile produit la même image dans six mois.
+# La version de R est explicite ; la relever est un changement délibéré.
+FROM rocker/r-ver:4.5.3
 
 LABEL org.opencontainers.image.title="TypR"
 LABEL org.opencontainers.image.description="A typed superset of R — transpiler and type checker"
@@ -20,7 +31,13 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Dépendances système des packages R que `typr init` installe (devtools, testthat)
+# Dépendances système des packages R que `typr init` installe (devtools, testthat).
+#
+# libuv1t64 est une dépendance d'exécution, pas de compilation : rocker/r-ver
+# récupère des paquets R déjà compilés, qui se lient à des bibliothèques que
+# l'image ne porte pas forcément. Sans elle, l'image se construisait très bien
+# et `library(devtools)` échouait au premier lancement sur
+# « libuv.so.1: cannot open shared object file ».
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -31,6 +48,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libfontconfig1-dev \
         libharfbuzz-dev \
         libfribidi-dev \
+        libuv1t64 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY bin/typr /usr/local/bin/typr
@@ -38,9 +56,16 @@ RUN chmod +x /usr/local/bin/typr
 
 # Les packages R dont TypR a besoin, préinstallés : `typr init` devient inutile
 # dans l'image, et un `typr build` fonctionne dès le premier démarrage.
-RUN R -e "install.packages(c('devtools', 'testthat', 'roxygen2'), repos='https://cloud.r-project.org')"
+# rocker/r-ver pointe deja sur un instantane CRAN date : on ne surcharge pas
+# `repos`, sinon on perd la reproductibilite qu'apporte l'image.
+RUN R -e "install.packages(c('devtools', 'testthat', 'roxygen2'))"
 
-RUN R --version && typr --version
+# Charger les packages, et pas seulement les installer : c'est le chargement qui
+# révèle une bibliothèque système absente. Le build doit échouer ici plutôt que
+# chez l'utilisateur.
+RUN R -e "library(devtools); library(testthat); library(roxygen2)" \
+    && R --version \
+    && typr --version
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Le job `Docker image` de la release v0.5.8 a échoué à la construction de l'image.
Cette PR corrige la cause, et une seconde qu'elle a révélée.

## L'échec

```
libcurl4-openssl-dev Depends libcurl4t64 (= 8.21.0-2)
but none of the choices are installable
```

Le Dockerfile partait de `r-base:latest`, construite sur Debian unstable. Son
index apt dérive en permanence par rapport aux bibliothèques figées dans l'image :
les paquets `-dev` réclament une version exacte de leur bibliothèque d'exécution,
et cette version finit par ne plus être celle qui est installée. Le build casse
donc sans qu'aucun fichier du dépôt n'ait changé — c'est une bombe à retardement,
pas un accident isolé.

Le socle devient `rocker/r-ver:4.5.3` : base Ubuntu LTS aux dépôts stables,
instantané CRAN épinglé, version de R explicite plutôt que « la dernière ».
L'appel à `install.packages()` perd son `repos=` pour ne pas contourner cet
instantané.

## Le second défaut

Le changement de socle a révélé un problème que l'ancien montage masquait :
`rocker/r-ver` installe des paquets R précompilés qui se lient à des
bibliothèques système absentes de l'image. L'image se construisait sans erreur,
puis `library(devtools)` mourait au premier lancement :

```
libuv.so.1: cannot open shared object file
Error: package 'usethis' could not be loaded
```

`libuv1t64` est ajouté à la liste apt. Surtout, l'étape de vérification **charge**
désormais les paquets au lieu de se contenter de les installer — c'est le
chargement qui révèle une bibliothèque manquante, et cet échec doit se produire
au build plutôt que chez l'utilisateur.

## Vérification

Image construite et lancée localement avec le binaire de la release v0.5.8 :

```
typr-cli 0.5.8
R version 4.5.3 (2026-03-11) -- "Reassured Reassurer"
R packages OK
```

## À savoir

Rejouer le job sur `v0.5.8` ne servirait à rien : il recharge le dépôt au tag,
donc l'ancien Dockerfile. Le correctif ne prendra effet qu'au tag suivant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFbyTtDrxK2DrN4m8xFqGC
