### PR TITLE
release v0.5.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 
 [[package]]
 name = "typr"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "typr-cli",
  "typr-core",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "typr-cli"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "typr-core"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "typr-lsp"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "typr-wasm"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ typr-cli.workspace = true
 typr-core.workspace = true
 
 [workspace.package]
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 authors = ["Fabrice Hategekimana <fab.hatege15@gmail.com>"]
 license = "Apache-2.0"

--- a/editors/rstudio/DESCRIPTION
+++ b/editors/rstudio/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: typr.runner
 Title: Run TypR from RStudio and Positron
-Version: 0.5.8
+Version: 0.5.9
 Authors@R: person("Fabrice", "Hategekimana", email = "fab.hatege15@gmail.com", role = c("aut", "cre"))
 Description: RStudio addins to create, check, build, test and run TypR projects
     without leaving the IDE. Wraps the TypR compiler binary, which is bundled in

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typr-language",
   "displayName": "TypR Tooling and Language Support",
   "description": "Language support for typR - A typed version of R with TypeScript-like typing and Rust-like syntax",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "publisher": "wedata-ch",
   "engines": {
     "vscode": "^1.109.0"


### PR DESCRIPTION
Bump de version seul : `Cargo.toml`, `Cargo.lock`, l'extension VS Code et le
runner RStudio passent tous à **0.5.9**. Aucun changement de code.

## Pourquoi cette version

v0.5.8 a débloqué l'essentiel — les quatre crates sont sorties ensemble et
`typr-lsp` existe enfin sur crates.io — mais deux canaux sont restés en carafe :

| Canal | v0.5.8 | Correctif |
|---|---|---|
| Docker Hub | build en échec | PR #20, déjà sur `main` |
| Playground WASM | `Invalid username or token` | `PLAYGROUND_DEPLOY_TOKEN` renouvelé |

Les deux correctifs sont en place mais ne peuvent pas s'appliquer
rétroactivement : le workflow recharge le dépôt **au tag**, et un numéro publié
sur crates.io ne peut pas être réutilisé. Il faut donc un tag neuf pour que la
chaîne rejoue en entier.

## Après la fusion

```
git switch main && git pull
nu publish.nu release --dry-run
nu publish.nu release
```

C'est le premier tag où les neuf jobs sont censés passer au vert. Les deux
seuls qui resteront en dégradation volontaire sont le Marketplace VS Code
(`VSCE_PAT` absent) et le rebuild de la doc (`DOCS_DISPATCH_TOKEN` absent) ;
tous deux émettent un avertissement et ne font pas échouer la release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFbyTtDrxK2DrN4m8xFqGC
