### PR TITLE
release v0.5.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 
 [[package]]
 name = "typr"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "typr-cli",
  "typr-core",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "typr-cli"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "typr-core"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "typr-lsp"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "typr-wasm"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ typr-cli.workspace = true
 typr-core.workspace = true
 
 [workspace.package]
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 authors = ["Fabrice Hategekimana <fab.hatege15@gmail.com>"]
 license = "Apache-2.0"

--- a/editors/rstudio/DESCRIPTION
+++ b/editors/rstudio/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: typr.runner
 Title: Run TypR from RStudio and Positron
-Version: 0.5.9
+Version: 0.5.10
 Authors@R: person("Fabrice", "Hategekimana", email = "fab.hatege15@gmail.com", role = c("aut", "cre"))
 Description: RStudio addins to create, check, build, test and run TypR projects
     without leaving the IDE. Wraps the TypR compiler binary, which is bundled in

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typr-language",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typr-language",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.2.3",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typr-language",
   "displayName": "TypR Tooling and Language Support",
   "description": "Language support for typR - A typed version of R with TypeScript-like typing and Rust-like syntax",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "publisher": "wedata-ch",
   "license": "Apache-2.0",
   "engines": {

--- a/todo.md
+++ b/todo.md
@@ -1,160 +1,111 @@
-# À faire — canaux éditeur
+# Canaux éditeur — état au 2026-09-07
 
-État au 2026-09-07, après la release v0.5.9.
+Deux canaux sur huit servaient une vieille version ou rien ; ils passent par deux
+registres distincts qui ne se parlent pas. Les deux servent désormais la version
+courante, `v0.5.9`.
 
-Six canaux sur huit servent la version courante. Les deux qui restent concernent
-tous les deux l'extension d'éditeur, et se traitent séparément parce qu'ils
-passent par deux registres distincts qui ne se parlent pas.
+| Canal               | Sert aujourd'hui | Vérifié le                    | Utilisateurs concernés                    |
+|---------------------|------------------|-------------------------------|-------------------------------------------|
+| VS Code Marketplace | **0.5.9**        | 2026-09-07 (publié à 12:41 Z) | VS Code                                   |
+| Open VSX            | **0.5.9**        | 2026-09-07 (publié à 13:15 Z) | Positron, VSCodium, Cursor, Gitpod, Theia |
 
-| Canal | Sert aujourd'hui | Utilisateurs concernés |
-|---|---|---|
-| VS Code Marketplace | **0.1.8** | VS Code |
-| Open VSX | **rien** | Positron, VSCodium, Cursor, Gitpod, Theia |
+## Ce qui a été fait
 
-Le travail de dépôt est fait : le job `vscode` de `release.yml` publie désormais
-sur les deux registres, et la licence de l'extension est alignée. **Ne restent
-que les actions manuelles ci-dessous** — obtenir deux jetons et poser deux
-secrets ; elles passent par un navigateur et un compte, rien d'automatisable ici.
+1. **Jetons posés** — `VSCE_PAT` et `OVSX_PAT` sont des secrets GitHub depuis le
+   2026-09-07.
+2. **Job** — `.github/workflows/release.yml` publie le `.vsix` déjà empaqueté sur
+   les deux registres. Les étapes Open VSX portent `if: always()` : un échec du
+   Marketplace (ex. republier une version déjà en ligne) ne doit pas bloquer la
+   publication Open VSX. Vérifié en conditions réelles sur le run 34126270113 —
+   Marketplace en échec, Open VSX en succès dans le même job.
+3. **Licences** — `editors/vscode/LICENSE` et le manifeste sont alignés sur
+   `Apache-2.0`. Voir la réserve ci-dessous : ce n'est pas encore visible en
+   ligne.
+4. **Lock** — `package-lock.json` porte la même version que `package.json`, et
+   `nu publish.nu sync` l'y maintient.
 
-Tant qu'elles ne sont pas faites, le job se termine en `success` avec un
-avertissement par canal : il empaquette bien le `.vsix` et l'attache à la
-release, mais ne publie nulle part. C'est une dégradation volontaire — un canal
-d'éditeur ne doit pas faire échouer la publication du compilateur — mais elle est
-silencieuse, d'où ce fichier.
+## Reste à faire — la licence n'est pas encore visible en ligne
 
----
+Open VSX affiche toujours l'extension comme **unlicensed** (`license: null` dans
+`https://open-vsx.org/api/wedata-ch/typr-language`).
 
-## 1. VS Code Marketplace — `VSCE_PAT`  *(à faire)*
+Ce n'est pas un oubli : le job de release fait un `checkout` **au tag**, et
+`v0.5.9` est antérieur au commit qui ajoute `"license": "Apache-2.0"` au
+manifeste. Le `.vsix` publié sur les deux registres est donc celui d'avant
+l'alignement. Seul le workflow, lui, vient de la branche depuis laquelle la
+release est relancée — d'où un job qui connaît Open VSX alors que le tag ne le
+connaît pas.
 
-L'extension est publiée sous l'éditeur `wedata-ch` (voir `publisher` dans
-`editors/vscode/package.json`). Le jeton doit appartenir à un compte qui a des
-droits sur cet éditeur.
-
-### Obtenir le jeton
-
-Le Marketplace n'a pas de gestion de jetons propre : il s'appuie sur Azure
-DevOps, ce qui explique le détour.
-
-1. Ouvrir `https://aex.dev.azure.com/me` — **en navigation privée**. C'est le
-   point d'entrée qui contourne la boucle de redirection rencontrée sur
-   `https://dev.azure.com` : cette dernière tente de deviner l'organisation et
-   boucle quand le compte n'en a pas encore.
-2. Créer une organisation si le compte n'en a aucune (n'importe quel nom, elle
-   ne sert qu'à héberger le jeton).
-3. Aller sur `https://dev.azure.com/<org>/_usersSettings/tokens`.
-4. **New Token**, avec exactement :
-   - *Organization* : **All accessible organizations** — indispensable, un jeton
-     limité à une seule organisation est refusé par `vsce` ;
-   - *Scopes* : **Custom defined** → **Marketplace: Manage** ;
-   - *Expiration* : 1 an (le maximum), et noter la date.
-5. Copier le jeton — il n'est affiché qu'une fois.
-
-### Poser le secret
+**Rien à corriger** : republier `v0.5.9` avec la licence supposerait de déplacer
+le tag, ce qui change un artefact déjà distribué. La `v0.5.10` portera la licence
+sans intervention. À revérifier après cette release :
 
 ```
-gh secret set VSCE_PAT --repo we-data-ch/typr
+curl -s https://open-vsx.org/api/wedata-ch/typr-language | grep license
 ```
 
-Coller le jeton à l'invite : la saisie est masquée et rien ne transite par un
-fichier ni par un historique de shell.
+## Vérifier
 
-### Vérifier
-
-Aucune modification du workflow n'est nécessaire — le job teste déjà la présence
-du secret. Rejouer la publication sur le tag courant :
-
-```
-gh workflow run release.yml -f tag=v0.5.9
-```
-
-Puis confirmer que le Marketplace a bougé :
+Marketplace :
 
 ```
 https://marketplace.visualstudio.com/items?itemName=wedata-ch.typr-language
 ```
 
-> **Si le compte n'a pas les droits sur l'éditeur `wedata-ch`** : le
-> propriétaire actuel doit ajouter le compte comme membre depuis
-> `https://marketplace.visualstudio.com/manage/publishers/wedata-ch`. Sans ça,
-> `vsce publish` échoue sur un 403 même avec un jeton valide.
-
----
-
-## 2. Open VSX — `OVSX_PAT` + namespace  *(job fait, jeton à faire)*
-
-Open VSX est un registre indépendant, géré par la fondation Eclipse. Positron,
-VSCodium et Cursor y cherchent leurs extensions et **n'ont pas accès au
-Marketplace** — la licence de ce dernier l'interdit aux produits non-Microsoft.
-Publier sur l'un ne publie donc rien sur l'autre : ce sont deux dépôts à
-alimenter, pas une redondance.
-
-À ce jour, un utilisateur de Positron ne peut pas installer l'extension TypR du
-tout.
-
-### Obtenir le jeton
-
-Plus simple que le Marketplace — pas de tenant Azure, pas de redirection.
-
-1. Se connecter sur `https://open-vsx.org` **avec le compte GitHub**.
-2. Accepter l'*Eclipse Publisher Agreement* (obligatoire, une seule fois, dans
-   les réglages du profil).
-3. *Settings* → *Access Tokens* → **Generate New Token**.
-
-### Créer le namespace
-
-Le nom du namespace doit correspondre au champ `publisher` du manifeste, donc
-`wedata-ch`. Il n'existe pas encore et se crée en ligne de commande :
-
-```
-npx ovsx create-namespace wedata-ch -p <le-jeton>
-```
-
-À faire **une seule fois**, avant la première publication. Sans lui, `ovsx
-publish` échoue sur un namespace inconnu.
-
-### Poser le secret
-
-```
-gh secret set OVSX_PAT --repo we-data-ch/typr
-```
-
-### Le job — **fait**
-
-Le job `vscode` de `.github/workflows/release.yml` porte maintenant les deux
-canaux : `OVSX_PAT` est déclaré dans son `env` (au niveau du **job**, un `env` de
-step n'étant pas visible depuis le `if` de ce même step), et deux étapes
-`Publish to Open VSX` / avertissement suivent le même modèle de dégradation que
-le Marketplace.
-
-Elles republient le `.vsix` **déjà empaqueté** plutôt que d'en produire un
-second : les deux registres servent ainsi un artefact bit pour bit identique à
-celui attaché à la release.
-
-`ovsx` est épinglé dans les `devDependencies` de l'extension, comme `@vscode/vsce`,
-pour que `npm ci` en installe une version connue au lieu d'en tirer une au hasard
-au moment de la release.
-
-### Vérifier
+Open VSX :
 
 ```
 https://open-vsx.org/extension/wedata-ch/typr-language
 ```
 
----
+En ligne de commande, sans navigateur ni jeton :
 
-## Point annexe repéré au passage — licences  *(fait)*
+```
+curl -s https://open-vsx.org/api/wedata-ch/typr-language | grep -E '"version"|"license"'
 
-Le manifeste ne déclarait pas de licence, et `editors/vscode/LICENSE` portait un
-texte **MIT** là où le workspace Rust, le `LICENSE` racine et le README disent
-`Apache-2.0`. Open VSX affiche la licence sur la page de l'extension et archive
-celle déclarée à chaque version : l'écart se corrige mal après coup.
+curl -s -X POST https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json;api-version=7.2-preview.1' \
+  -d '{"filters":[{"criteria":[{"filterType":7,"value":"wedata-ch.typr-language"}],"pageSize":1,"pageNumber":1}],"flags":950}'
+```
 
-Tout est aligné sur **Apache-2.0** : `editors/vscode/LICENSE` reprend le texte du
-dépôt et le manifeste déclare `"license": "Apache-2.0"`.
+## Pièges passés, à connaître pour la prochaine rotation de jeton
 
-## Point annexe repéré au passage — `package-lock.json` désynchronisé  *(fait)*
+### `VSCE_PAT` — compte et portée
 
-Le lock de l'extension annonçait encore `vscode_extension` en `1.0.0` : `nu
-publish.nu sync` mettait à jour `package.json` mais pas le lock, qui dérivait à
-chaque version. `sync-editors` propage désormais la version aux deux, et le lock
-a été régénéré.
+- Un jeton Azure DevOps **limité à une seule organisation** est refusé par
+  `vsce` : choisir **All accessible organizations**.
+- La portée doit être **Marketplace: Manage**.
+- Sans les droits sur l'éditeur `wedata-ch`, `vsce publish` échoue en 403 même
+  avec un jeton valide. Le jeton doit appartenir au **même compte** que celui
+  qui a créé l'éditeur `wedata-ch` ; un autre compte doit être ajouté comme
+  membre par le propriétaire depuis
+  `https://marketplace.visualstudio.com/manage/publishers/wedata-ch`.
+- Créé le 2026-09-07 avec une expiration à un an : il tombe donc vers le
+  **2027-09-07**. Le renouveler avant, en repassant par
+  `https://aex.dev.azure.com/me` puis
+  `https://dev.azure.com/<org>/_usersSettings/tokens`.
+
+### `OVSX_PAT` et namespace
+
+- Le namespace `wedata-ch` existe désormais sur Open VSX — ne pas le recréer.
+- `ovsx` est épinglé dans les `devDependencies` de l'extension, pour que `npm ci`
+  en installe une version connue plutôt que d'en tirer une au hasard au moment de
+  la release.
+- Sans namespace, `ovsx publish` échoue sur un namespace inconnu.
+- La propagation du registre prend quelques secondes après la publication : ne
+  pas s'alarmer d'un 404 immédiat.
+
+### Rejouer une release
+
+- `gh workflow run release.yml -f tag=v0.5.9` régénère le `.vsix`, le réattache à
+  la release et republie. Comme v0.5.9 est déjà sur le Marketplace, `vsce publish`
+  échoue (`wedata-ch.typr-language v0.5.9 already exists.`) : normal et attendu.
+  Le job finit donc en `failure` sur un rejeu, mais le canal Open VSX continue de
+  tourner grâce à `if: always()`.
+- Le rejeu prend le **workflow de la branche** choisie pour le dispatch, mais le
+  **code du tag**. Une correction de workflow prend donc effet tout de suite, une
+  correction de source seulement au tag suivant.
+- C'est le job `verify`, pas le job `vscode`, qui vérifie que le tag et les
+  versions de `Cargo.toml`, de `package.json` et de la `DESCRIPTION` RStudio
+  concordent ; les autres jobs en dépendent (`needs: verify`).


### PR DESCRIPTION
Bump de version : 0.5.9 → 0.5.10.

Aucun changement de code — ce commit n'existe que pour porter le numéro de version jusqu'à `main`, d'où le tag sera posé.