### PR TITLE
release v0.5.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 
 [[package]]
 name = "typr"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "typr-cli",
  "typr-core",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "typr-cli"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "typr-core"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "typr-lsp"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "typr-mcp"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "typr-wasm"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ typr-cli.workspace = true
 typr-core.workspace = true
 
 [workspace.package]
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 authors = ["Fabrice Hategekimana <fab.hatege15@gmail.com>"]
 license = "Apache-2.0"

--- a/editors/rstudio/DESCRIPTION
+++ b/editors/rstudio/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: typr.runner
 Title: Run TypR from RStudio and Positron
-Version: 0.5.10
+Version: 0.5.11
 Authors@R: person("Fabrice", "Hategekimana", email = "fab.hatege15@gmail.com", role = c("aut", "cre"))
 Description: RStudio addins to create, check, build, test and run TypR projects
     without leaving the IDE. Wraps the TypR compiler binary, which is bundled in

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typr-language",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typr-language",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.2.3",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typr-language",
   "displayName": "TypR Tooling and Language Support",
   "description": "Language support for typR - A typed version of R with TypeScript-like typing and Rust-like syntax",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "publisher": "wedata-ch",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Bump de version : 0.5.10 → 0.5.11.

Aucun changement de code — ce commit n'existe que pour porter le numéro de version jusqu'à `main`, d'où le tag sera posé.